### PR TITLE
JPA 연동 및 Repository 테스트 코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,12 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.batch:spring-batch-test'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/fastcampus/pass/PassBatchApplication.java
+++ b/src/main/java/com/fastcampus/pass/PassBatchApplication.java
@@ -1,10 +1,42 @@
 package com.fastcampus.pass;
 
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class PassBatchApplication {
+
+    private final JobBuilderFactory jobBuilderFactory;
+
+    private final StepBuilderFactory stepBuilderFactory;
+
+    public PassBatchApplication(JobBuilderFactory jobBuilderFactory, StepBuilderFactory stepBuilderFactory) {
+        this.jobBuilderFactory = jobBuilderFactory;
+        this.stepBuilderFactory = stepBuilderFactory;
+    }
+
+    @Bean
+    public Step passStep() {
+        return this.stepBuilderFactory.get("passStep")
+                .tasklet((contribution, chunkContext) -> {
+                    System.out.println("Execute PassSetup");
+                    return RepeatStatus.FINISHED;
+                }).build();
+    }
+
+    @Bean
+    public Job passJob() {
+        return this.jobBuilderFactory.get("passJob")
+                .start(passStep())
+                .build();
+    }
+
 
     public static void main(String[] args) {
         SpringApplication.run(PassBatchApplication.class, args);

--- a/src/main/java/com/fastcampus/pass/repository/packaze/PackageRepository.java
+++ b/src/main/java/com/fastcampus/pass/repository/packaze/PackageRepository.java
@@ -1,6 +1,25 @@
 package com.fastcampus.pass.repository.packaze;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface PackageRepository extends JpaRepository<PackageEntity, Integer> {
+    List<PackageEntity> findByCreatedAtAfter(LocalDateTime dateTime, Pageable pageable);
+
+
+    @Transactional
+    @Modifying
+    @Query(value = "UPDATE PackageEntity p " +
+            "          SET p.count  = :count," +
+            "              p.period = :period" +
+            "        WHERE p.packageSeq = :packageSeq")
+    int updateCountAndPeriod(Integer packageSeq, Integer count, Integer period);
+
+
 }

--- a/src/test/java/com/fastcampus/pass/repository/packaze/PackageRepositoryTest.java
+++ b/src/test/java/com/fastcampus/pass/repository/packaze/PackageRepositoryTest.java
@@ -1,0 +1,93 @@
+package com.fastcampus.pass.repository.packaze;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@SpringBootTest
+@ActiveProfiles("test")
+class PackageRepositoryTest {
+
+    @Autowired
+    private PackageRepository packageRepository;
+
+    @Test
+    public void test_save() {
+        // given
+        PackageEntity packageEntity = new PackageEntity();
+        packageEntity.setPackageName("바디 챌린지 PT 12주");
+        packageEntity.setPeriod(84);
+
+        // when
+        packageRepository.save(packageEntity);
+
+        // then
+        assertNotNull(packageEntity.getPackageSeq());
+    }
+
+    @Test
+    public void test_findByCreatedAtAfter() {
+        // given
+        LocalDateTime dateTime = LocalDateTime.now().minusMinutes(1);
+
+        PackageEntity packageEntity0 = new PackageEntity();
+        packageEntity0.setPackageName("학생 전용 3개월");
+        packageEntity0.setPeriod(90);
+        packageRepository.save(packageEntity0);
+
+        PackageEntity packageEntity1 = new PackageEntity();
+        packageEntity1.setPackageName("학생 전용 6개월");
+        packageEntity1.setPeriod(180);
+        packageRepository.save(packageEntity1);
+
+        // when
+        final List<PackageEntity> packageEntities = packageRepository.findByCreatedAtAfter(dateTime, PageRequest.of(0, 1, Sort.by("packageSeq").descending()));
+
+        // then
+        assertEquals(1, packageEntities.size());
+        assertEquals(packageEntity1.getPackageSeq(), packageEntities.get(0).getPackageSeq());
+    }
+
+    @Test
+    public void test_updateByCountAndPeriod() {
+        // given
+        PackageEntity packageEntity = new PackageEntity();
+        packageEntity.setPackageName("바디프로필 이벤트 4개월");
+        packageEntity.setPeriod(90);
+        packageRepository.save(packageEntity);
+
+        // when
+        int updatedCount = packageRepository.updateCountAndPeriod(packageEntity.getPackageSeq(), 30, 120);
+        final PackageEntity updatedPackageEntity = packageRepository.findById(packageEntity.getPackageSeq()).get();
+
+        // then
+        assertEquals(1, updatedCount);
+        assertEquals(30, updatedPackageEntity.getCount());
+        assertEquals(120, updatedPackageEntity.getPeriod());
+    }
+
+    @Test
+    public void test_delete() {
+        // given
+        PackageEntity packageEntity = new PackageEntity();
+        packageEntity.setPackageName("제거할 이용권");
+        packageEntity.setCount(1);
+        PackageEntity newPackageEntity = packageRepository.save(packageEntity);
+
+        // when
+        packageRepository.deleteById(newPackageEntity.getPackageSeq());
+
+        // then
+        assertTrue(packageRepository.findById(newPackageEntity.getPackageSeq()).isEmpty());
+    }
+}


### PR DESCRIPTION
이번 PR은 JPA 연동을 통해 MySQL DB와의 Repository 테스트 코드를 추가하는 작업이다.
- JPA를 활용한 기본 CRUD Repository 구현
- Spring Batch 설정 및 Job/Step 설정
- 패키지 엔티티 관련 테스트 코드 추가 (저장, 조회, 수정, 삭제 기능)