### PR TITLE
이용권 만료 처리 배치 구현

### DIFF
--- a/src/main/java/com/example/pass/PassBatchApplication.java
+++ b/src/main/java/com/example/pass/PassBatchApplication.java
@@ -1,4 +1,4 @@
-package com.fastcampus.pass;
+package com.example.pass;
 
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;

--- a/src/main/java/com/example/pass/config/BatchConfig.java
+++ b/src/main/java/com/example/pass/config/BatchConfig.java
@@ -1,4 +1,4 @@
-package com.fastcampus.pass.config;
+package com.example.pass.config;
 
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/example/pass/config/JpaConfig.java
+++ b/src/main/java/com/example/pass/config/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.fastcampus.pass.config;
+package com.example.pass.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/example/pass/job/pass/ExpirePassesJobConfig.java
+++ b/src/main/java/com/example/pass/job/pass/ExpirePassesJobConfig.java
@@ -1,0 +1,92 @@
+package com.example.pass.job.pass;
+
+import com.example.pass.repository.pass.PassEntity;
+import com.example.pass.repository.pass.PassStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JpaCursorItemReader;
+import org.springframework.batch.item.database.JpaItemWriter;
+import org.springframework.batch.item.database.builder.JpaCursorItemReaderBuilder;
+import org.springframework.batch.item.database.builder.JpaItemWriterBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManagerFactory;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Configuration
+@EnableBatchProcessing
+public class ExpirePassesJobConfig {
+    private final int CHUNK_SIZE = 1;
+
+    // @EnableBatchProcessing로 인해 Bean으로 제공된 JobBuilderFactory, StepBuilderFactory
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final EntityManagerFactory entityManagerFactory;
+
+    public ExpirePassesJobConfig(JobBuilderFactory jobBuilderFactory, StepBuilderFactory stepBuilderFactory, EntityManagerFactory entityManagerFactory) {
+        this.jobBuilderFactory = jobBuilderFactory;
+        this.stepBuilderFactory = stepBuilderFactory;
+        this.entityManagerFactory = entityManagerFactory;
+    }
+
+    @Bean
+    public Job expirePassesJob() {
+        return this.jobBuilderFactory.get("expirePassesJob")
+                .start(expirePassesStep())
+                .build();
+    }
+
+    @Bean
+    public Step expirePassesStep() {
+        return this.stepBuilderFactory.get("expirePassesStep")
+                .<PassEntity, PassEntity>chunk(CHUNK_SIZE)
+                .reader(expirePassesItemReader())
+                .processor(expirePassesItemProcessor())
+                .writer(expirePassesItemWriter())
+                .build();
+
+    }
+
+    /**
+     * JpaCursorItemReader: JpaPagingItemReader만 지원하다가 Spring 4.3에서 추가되었습니다.
+     * 페이징 기법보다 보다 높은 성능으로, 데이터 변경에 무관한 무결성 조회가 가능합니다.
+     */
+    @Bean
+    @StepScope
+    public JpaCursorItemReader<PassEntity> expirePassesItemReader() {
+        return new JpaCursorItemReaderBuilder<PassEntity>()
+                .name("expirePassesItemReader")
+                .entityManagerFactory(entityManagerFactory)
+                // 상태(status)가 진행중이며, 종료일시(endedAt)이 현재 시점보다 과거일 경우 만료 대상이 됩니다.
+                .queryString("select p from PassEntity p where p.status = :status and p.endedAt <= :endedAt")
+                .parameterValues(Map.of("status", PassStatus.PROGRESSED, "endedAt", LocalDateTime.now()))
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<PassEntity, PassEntity> expirePassesItemProcessor() {
+        return passEntity -> {
+            passEntity.setStatus(PassStatus.EXPIRED);
+            passEntity.setExpiredAt(LocalDateTime.now());
+            return passEntity;
+        };
+    }
+
+    /**
+     * JpaItemWriter: JPA의 영속성 관리를 위해 EntityManager를 필수로 설정해줘야 합니다.
+     */
+    @Bean
+    public JpaItemWriter<PassEntity> expirePassesItemWriter() {
+        return new JpaItemWriterBuilder<PassEntity>()
+                .entityManagerFactory(entityManagerFactory)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/pass/repository/BaseEntity.java
+++ b/src/main/java/com/example/pass/repository/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.fastcampus.pass.repository;
+package com.example.pass.repository;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;

--- a/src/main/java/com/example/pass/repository/booking/BookingEntity.java
+++ b/src/main/java/com/example/pass/repository/booking/BookingEntity.java
@@ -1,6 +1,6 @@
-package com.fastcampus.pass.repository.booking;
+package com.example.pass.repository.booking;
 
-import com.fastcampus.pass.repository.BaseEntity;
+import com.example.pass.repository.BaseEntity;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;

--- a/src/main/java/com/example/pass/repository/booking/BookingRepository.java
+++ b/src/main/java/com/example/pass/repository/booking/BookingRepository.java
@@ -1,4 +1,4 @@
-package com.fastcampus.pass.repository.booking;
+package com.example.pass.repository.booking;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/example/pass/repository/booking/BookingStatus.java
+++ b/src/main/java/com/example/pass/repository/booking/BookingStatus.java
@@ -1,0 +1,5 @@
+package com.example.pass.repository.booking;
+
+public enum BookingStatus {
+    READY, PROGRESSED, COMPLETED, CANCELLED
+}

--- a/src/main/java/com/example/pass/repository/packaze/PackageEntity.java
+++ b/src/main/java/com/example/pass/repository/packaze/PackageEntity.java
@@ -1,6 +1,6 @@
-package com.fastcampus.pass.repository.packaze;
+package com.example.pass.repository.packaze;
 
-import com.fastcampus.pass.repository.BaseEntity;
+import com.example.pass.repository.BaseEntity;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;

--- a/src/main/java/com/example/pass/repository/packaze/PackageRepository.java
+++ b/src/main/java/com/example/pass/repository/packaze/PackageRepository.java
@@ -1,4 +1,4 @@
-package com.fastcampus.pass.repository.packaze;
+package com.example.pass.repository.packaze;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/example/pass/repository/pass/PassEntity.java
+++ b/src/main/java/com/example/pass/repository/pass/PassEntity.java
@@ -1,6 +1,6 @@
-package com.fastcampus.pass.repository.pass;
+package com.example.pass.repository.pass;
 
-import com.fastcampus.pass.repository.BaseEntity;
+import com.example.pass.repository.BaseEntity;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -20,6 +20,7 @@ public class PassEntity extends BaseEntity {
     private Integer packageSeq;
     private String userId;
 
+    @Enumerated(EnumType.STRING)
     private PassStatus status;
     private Integer remainingCount;
 

--- a/src/main/java/com/example/pass/repository/pass/PassRepository.java
+++ b/src/main/java/com/example/pass/repository/pass/PassRepository.java
@@ -1,4 +1,4 @@
-package com.fastcampus.pass.repository.pass;
+package com.example.pass.repository.pass;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/example/pass/repository/pass/PassStatus.java
+++ b/src/main/java/com/example/pass/repository/pass/PassStatus.java
@@ -1,0 +1,5 @@
+package com.example.pass.repository.pass;
+
+public enum PassStatus {
+    READY, PROGRESSED, EXPIRED
+}

--- a/src/main/java/com/example/pass/repository/user/UserEntity.java
+++ b/src/main/java/com/example/pass/repository/user/UserEntity.java
@@ -1,6 +1,6 @@
-package com.fastcampus.pass.repository.user;
+package com.example.pass.repository.user;
 
-import com.fastcampus.pass.repository.BaseEntity;
+import com.example.pass.repository.BaseEntity;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;

--- a/src/main/java/com/example/pass/repository/user/UserRepository.java
+++ b/src/main/java/com/example/pass/repository/user/UserRepository.java
@@ -1,4 +1,4 @@
-package com.fastcampus.pass.repository.user;
+package com.example.pass.repository.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/example/pass/repository/user/UserStatus.java
+++ b/src/main/java/com/example/pass/repository/user/UserStatus.java
@@ -1,4 +1,4 @@
-package com.fastcampus.pass.repository.user;
+package com.example.pass.repository.user;
 
 public enum UserStatus {
     ACTIVE, INACTIVE

--- a/src/main/java/com/fastcampus/pass/repository/booking/BookingStatus.java
+++ b/src/main/java/com/fastcampus/pass/repository/booking/BookingStatus.java
@@ -1,5 +1,0 @@
-package com.fastcampus.pass.repository.booking;
-
-public enum BookingStatus {
-    READY, IN_PROGRESS, COMPLETED, CANCELLED
-}

--- a/src/main/java/com/fastcampus/pass/repository/pass/PassStatus.java
+++ b/src/main/java/com/fastcampus/pass/repository/pass/PassStatus.java
@@ -1,5 +1,0 @@
-package com.fastcampus.pass.repository.pass;
-
-public enum PassStatus {
-    READY, IN_PROGRESS, EXPIRED
-}

--- a/src/test/java/com/example/pass/PassBatchApplicationTests.java
+++ b/src/test/java/com/example/pass/PassBatchApplicationTests.java
@@ -1,4 +1,4 @@
-package com.fastcampus.pass;
+package com.example.pass;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/example/pass/config/TestBatchConfig.java
+++ b/src/test/java/com/example/pass/config/TestBatchConfig.java
@@ -1,0 +1,19 @@
+package com.example.pass.config;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableJpaAuditing
+@EnableAutoConfiguration
+@EnableBatchProcessing
+@EntityScan("com.example.pass.repository")
+@EnableJpaRepositories("com.example.pass.repository")
+@EnableTransactionManagement
+public class TestBatchConfig {
+}

--- a/src/test/java/com/example/pass/job/pass/ExpirePassesJobConfigTest.java
+++ b/src/test/java/com/example/pass/job/pass/ExpirePassesJobConfigTest.java
@@ -1,0 +1,73 @@
+package com.example.pass.job.pass;
+
+import com.example.pass.config.TestBatchConfig;
+import com.example.pass.repository.pass.PassEntity;
+import com.example.pass.repository.pass.PassRepository;
+import com.example.pass.repository.pass.PassStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+@SpringBatchTest
+@SpringBootTest
+@ActiveProfiles("test")
+@ContextConfiguration(classes = {ExpirePassesJobConfig.class, TestBatchConfig.class})
+public class ExpirePassesJobConfigTest {
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private PassRepository passRepository;
+
+    @Test
+    public void test_expirePassesStep() throws Exception {
+        // given
+        addPassEntities(10);
+
+        // when
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+        JobInstance jobInstance = jobExecution.getJobInstance();
+
+        // then
+        assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+        assertEquals("expirePassesJob", jobInstance.getJobName());
+
+    }
+
+    private void addPassEntities(int size) {
+        final LocalDateTime now = LocalDateTime.now();
+        final Random random = new Random();
+
+        List<PassEntity> passEntities = new ArrayList<>();
+        for (int i = 0; i < size; ++i) {
+            PassEntity passEntity = new PassEntity();
+            passEntity.setPackageSeq(1);
+            passEntity.setUserId("A" + 1000000 + i);
+            passEntity.setStatus(PassStatus.PROGRESSED);
+            passEntity.setRemainingCount(random.nextInt(11));
+            passEntity.setStartedAt(now.minusDays(60));
+            passEntity.setEndedAt(now.minusDays(1));
+            passEntities.add(passEntity);
+
+        }
+        passRepository.saveAll(passEntities);
+
+    }
+
+}

--- a/src/test/java/com/example/pass/repository/packaze/PackageRepositoryTest.java
+++ b/src/test/java/com/example/pass/repository/packaze/PackageRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.fastcampus.pass.repository.packaze;
+package com.example.pass.repository.packaze;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- PassEntity의 status 필드에 @Enumerated(EnumType.STRING) 어노테이션을 추가하여 Enum이 문자열로 저장되도록 변경
- Spring Batch를 활용하여 이용권 만료 처리 배치 작업을 구현
- ItemReader와 ItemWriter를 활용한 Chunk 기반의 Step을 설정하고, 만료 처리 로직을 테스트
- 만료된 이용권의 상태가 성공적으로 업데이트되었음을 확인