### PR TITLE
Batch 통계 데이터 생성

### DIFF
--- a/db/initdb.d/create_table.sql
+++ b/db/initdb.d/create_table.sql
@@ -89,3 +89,14 @@ CREATE TABLE `notification`
     `modified_at`      timestamp              DEFAULT NULL COMMENT '수정 일시',
     PRIMARY KEY (`notification_seq`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='알람';
+
+CREATE TABLE `statistics`
+(
+    `statistics_seq`      int       NOT NULL AUTO_INCREMENT COMMENT '통계 순번',
+    `statistics_at`       timestamp NOT NULL COMMENT '통계 일시',
+    `all_count`           int       NOT NULL DEFAULT 0 COMMENT '전체 횟수',
+    `attended_count`      int       NOT NULL DEFAULT 0 COMMENT '출석 횟수',
+    `cancelled_count`     int       NOT NULL DEFAULT 0 COMMENT '취소 횟수',
+    PRIMARY KEY (`statistics_seq`),
+    INDEX idx_statistics_at (`statistics_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='통계';

--- a/src/main/java/com/example/pass/job/statistics/MakeDailyStatisticsTasklet.java
+++ b/src/main/java/com/example/pass/job/statistics/MakeDailyStatisticsTasklet.java
@@ -1,0 +1,55 @@
+package com.example.pass.job.statistics;
+
+import com.example.pass.repository.statistics.AggregatedStatistics;
+import com.example.pass.repository.statistics.StatisticsRepository;
+import com.example.pass.util.CustomCSVWriter;
+import com.example.pass.util.LocalDateTimeUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@StepScope
+public class MakeDailyStatisticsTasklet implements Tasklet {
+    @Value("#{jobParameters[from]}")
+    private String fromString;
+    @Value("#{jobParameters[to]}")
+    private String toString;
+    private final StatisticsRepository statisticsRepository;
+
+    public MakeDailyStatisticsTasklet(StatisticsRepository statisticsRepository) {
+        this.statisticsRepository = statisticsRepository;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        final LocalDateTime from = LocalDateTimeUtils.parse(fromString);
+        final LocalDateTime to = LocalDateTimeUtils.parse(toString);
+
+        final List<AggregatedStatistics> statisticsList = statisticsRepository.findByStatisticsAtBetweenAndGroupBy(from, to);
+
+        List<String[]> data = new ArrayList<>();
+        data.add(new String[]{"statisticsAt", "allCount", "attendedCount", "cancelledCount"});
+        for (AggregatedStatistics statistics : statisticsList) {
+            data.add(new String[]{
+                    LocalDateTimeUtils.format(statistics.getStatisticsAt()),
+                    String.valueOf(statistics.getAllCount()),
+                    String.valueOf(statistics.getAttendedCount()),
+                    String.valueOf(statistics.getCancelledCount())
+            });
+        }
+        CustomCSVWriter.write("daily_statistics_" + LocalDateTimeUtils.format(from, LocalDateTimeUtils.YYYY_MM_DD) + ".csv", data);
+        return RepeatStatus.FINISHED;
+
+    }
+}

--- a/src/main/java/com/example/pass/job/statistics/MakeStatisticsJobConfig.java
+++ b/src/main/java/com/example/pass/job/statistics/MakeStatisticsJobConfig.java
@@ -1,0 +1,140 @@
+package com.example.pass.job.statistics;
+
+import com.example.pass.repository.booking.BookingEntity;
+import com.example.pass.repository.statistics.StatisticsEntity;
+import com.example.pass.repository.statistics.StatisticsRepository;
+import com.example.pass.util.LocalDateTimeUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.FlowBuilder;
+import org.springframework.batch.core.job.flow.Flow;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaCursorItemReader;
+import org.springframework.batch.item.database.builder.JpaCursorItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+
+import javax.persistence.EntityManagerFactory;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Configuration
+public class MakeStatisticsJobConfig {
+    private final int CHUNK_SIZE = 10;
+
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final EntityManagerFactory entityManagerFactory;
+    private final StatisticsRepository statisticsRepository;
+    private final MakeDailyStatisticsTasklet makeDailyStatisticsTasklet;
+    private final MakeWeeklyStatisticsTasklet makeWeeklyStatisticsTasklet;
+
+    public MakeStatisticsJobConfig(JobBuilderFactory jobBuilderFactory, StepBuilderFactory stepBuilderFactory, EntityManagerFactory entityManagerFactory, StatisticsRepository statisticsRepository, MakeDailyStatisticsTasklet makeDailyStatisticsTasklet, MakeWeeklyStatisticsTasklet makeWeeklyStatisticsTasklet) {
+        this.jobBuilderFactory = jobBuilderFactory;
+        this.stepBuilderFactory = stepBuilderFactory;
+        this.entityManagerFactory = entityManagerFactory;
+        this.statisticsRepository = statisticsRepository;
+        this.makeDailyStatisticsTasklet = makeDailyStatisticsTasklet;
+        this.makeWeeklyStatisticsTasklet = makeWeeklyStatisticsTasklet;
+    }
+
+    @Bean
+    public Job makeStatisticsJob() {
+        Flow addStatisticsFlow = new FlowBuilder<Flow>("addStatisticsFlow")
+                .start(addStatisticsStep())
+                .build();
+
+        Flow makeDailyStatisticsFlow = new FlowBuilder<Flow>("makeDailyStatisticsFlow")
+                .start(makeDailyStatisticsStep())
+                .build();
+
+        Flow makeWeeklyStatisticsFlow = new FlowBuilder<Flow>("makeWeeklyStatisticsFlow")
+                .start(makeWeeklyStatisticsStep())
+                .build();
+
+        Flow parallelMakeStatisticsFlow = new FlowBuilder<Flow>("parallelMakeStatisticsFlow")
+                .split(new SimpleAsyncTaskExecutor())
+                .add(makeDailyStatisticsFlow, makeWeeklyStatisticsFlow)
+                .build();
+
+        return this.jobBuilderFactory.get("makeStatisticsJob")
+                .start(addStatisticsFlow)
+                .next(parallelMakeStatisticsFlow)
+                .build()
+                .build();
+    }
+
+    @Bean
+    public Step addStatisticsStep() {
+        return this.stepBuilderFactory.get("addStatisticsStep")
+                .<BookingEntity, BookingEntity>chunk(CHUNK_SIZE)
+                .reader(addStatisticsItemReader(null, null))
+                .writer(addStatisticsItemWriter())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaCursorItemReader<BookingEntity> addStatisticsItemReader(@Value("#{jobParameters[from]}") String fromString, @Value("#{jobParameters[to]}") String toString) {
+        final LocalDateTime from = LocalDateTimeUtils.parse(fromString);
+        final LocalDateTime to = LocalDateTimeUtils.parse(toString);
+
+        return new JpaCursorItemReaderBuilder<BookingEntity>()
+                .name("usePassesItemReader")
+                .entityManagerFactory(entityManagerFactory)
+                // JobParameter를 받아 종료 일시(endedAt) 기준으로 통계 대상 예약(Booking)을 조회합니다.
+                .queryString("select b from BookingEntity b where b.endedAt between :from and :to")
+                .parameterValues(Map.of("from", from, "to", to))
+                .build();
+    }
+
+    @Bean
+    public ItemWriter<BookingEntity> addStatisticsItemWriter() {
+        return bookingEntities -> {
+            Map<LocalDateTime, StatisticsEntity> statisticsEntityMap = new LinkedHashMap<>();
+
+            for (BookingEntity bookingEntity : bookingEntities) {
+                final LocalDateTime statisticsAt = bookingEntity.getStatisticsAt();
+                StatisticsEntity statisticsEntity = statisticsEntityMap.get(statisticsAt);
+
+                if (statisticsEntity == null) {
+                    statisticsEntityMap.put(statisticsAt, StatisticsEntity.create(bookingEntity));
+
+                } else {
+                    statisticsEntity.add(bookingEntity);
+
+                }
+
+            }
+            final List<StatisticsEntity> statisticsEntities = new ArrayList<>(statisticsEntityMap.values());
+            statisticsRepository.saveAll(statisticsEntities);
+            log.info("### addStatisticsStep 종료");
+
+        };
+    }
+
+    @Bean
+    public Step makeDailyStatisticsStep() {
+        return this.stepBuilderFactory.get("makeDailyStatisticsStep")
+                .tasklet(makeDailyStatisticsTasklet)
+                .build();
+    }
+
+    @Bean
+    public Step makeWeeklyStatisticsStep() {
+        return this.stepBuilderFactory.get("makeWeeklyStatisticsStep")
+                .tasklet(makeWeeklyStatisticsTasklet)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/pass/job/statistics/MakeWeeklyStatisticsTasklet.java
+++ b/src/main/java/com/example/pass/job/statistics/MakeWeeklyStatisticsTasklet.java
@@ -1,0 +1,74 @@
+package com.example.pass.job.statistics;
+
+import com.example.pass.repository.statistics.AggregatedStatistics;
+import com.example.pass.repository.statistics.StatisticsRepository;
+import com.example.pass.util.CustomCSVWriter;
+import com.example.pass.util.LocalDateTimeUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@StepScope
+public class MakeWeeklyStatisticsTasklet implements Tasklet {
+    @Value("#{jobParameters[from]}")
+    private String fromString;
+    @Value("#{jobParameters[to]}")
+    private String toString;
+
+    private final StatisticsRepository statisticsRepository;
+
+    public MakeWeeklyStatisticsTasklet(StatisticsRepository statisticsRepository) {
+        this.statisticsRepository = statisticsRepository;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        final LocalDateTime from = LocalDateTimeUtils.parse(fromString);
+        final LocalDateTime to = LocalDateTimeUtils.parse(toString);
+
+        final List<AggregatedStatistics> statisticsList = statisticsRepository.findByStatisticsAtBetweenAndGroupBy(from, to);
+        Map<Integer, AggregatedStatistics> weeklyStatisticsEntityMap = new LinkedHashMap<>();
+
+        for (AggregatedStatistics statistics : statisticsList) {
+            int week = LocalDateTimeUtils.getWeekOfYear(statistics.getStatisticsAt());
+            AggregatedStatistics savedStatisticsEntity = weeklyStatisticsEntityMap.get(week);
+
+            if (savedStatisticsEntity == null) {
+                weeklyStatisticsEntityMap.put(week, statistics);
+
+            } else {
+                savedStatisticsEntity.merge(statistics);
+
+            }
+
+        }
+
+        List<String[]> data = new ArrayList<>();
+        data.add(new String[]{"week", "allCount", "attendedCount", "cancelledCount"});
+        weeklyStatisticsEntityMap.forEach((week, statistics) -> {
+            data.add(new String[]{
+                    "Week " + week,
+                    String.valueOf(statistics.getAllCount()),
+                    String.valueOf(statistics.getAttendedCount()),
+                    String.valueOf(statistics.getCancelledCount())
+            });
+
+        });
+        CustomCSVWriter.write("weekly_statistics_" + LocalDateTimeUtils.format(from, LocalDateTimeUtils.YYYY_MM_DD) + ".csv", data);
+        return RepeatStatus.FINISHED;
+
+    }
+}

--- a/src/main/java/com/example/pass/repository/statistics/AggregatedStatistics.java
+++ b/src/main/java/com/example/pass/repository/statistics/AggregatedStatistics.java
@@ -1,0 +1,26 @@
+package com.example.pass.repository.statistics;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+public class AggregatedStatistics {
+    private LocalDateTime statisticsAt; // 일 단위
+    private long allCount;
+    private long attendedCount;
+    private long cancelledCount;
+
+    public void merge(final AggregatedStatistics statistics) {
+        this.allCount += statistics.getAllCount();
+        this.attendedCount += statistics.getAttendedCount();
+        this.cancelledCount += statistics.getCancelledCount();
+
+    }
+}

--- a/src/main/java/com/example/pass/repository/statistics/StatisticsEntity.java
+++ b/src/main/java/com/example/pass/repository/statistics/StatisticsEntity.java
@@ -1,0 +1,57 @@
+package com.example.pass.repository.statistics;
+
+import com.example.pass.repository.booking.BookingEntity;
+import com.example.pass.repository.booking.BookingStatus;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@ToString
+@Entity
+@Table(name = "statistics")
+public class StatisticsEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // 기본 키 생성을 DB에 위임합니다. (AUTO_INCREMENT)
+    private Integer statisticsSeq;
+    private LocalDateTime statisticsAt; // 일 단위
+
+    private int allCount;
+    private int attendedCount;
+    private int cancelledCount;
+
+    public static StatisticsEntity create(final BookingEntity bookingEntity) {
+        StatisticsEntity statisticsEntity = new StatisticsEntity();
+        statisticsEntity.setStatisticsAt(bookingEntity.getStatisticsAt());
+        statisticsEntity.setAllCount(1);
+        if (bookingEntity.isAttended()) {
+            statisticsEntity.setAttendedCount(1);
+
+        }
+        if (BookingStatus.CANCELLED.equals(bookingEntity.getStatus())) {
+            statisticsEntity.setCancelledCount(1);
+
+        }
+        return statisticsEntity;
+
+    }
+
+    public void add(final BookingEntity bookingEntity) {
+        this.allCount++;
+
+        if (bookingEntity.isAttended()) {
+            this.attendedCount++;
+
+        }
+        if (BookingStatus.CANCELLED.equals(bookingEntity.getStatus())) {
+            this.cancelledCount++;
+
+        }
+
+    }
+
+}

--- a/src/main/java/com/example/pass/repository/statistics/StatisticsRepository.java
+++ b/src/main/java/com/example/pass/repository/statistics/StatisticsRepository.java
@@ -1,0 +1,18 @@
+package com.example.pass.repository.statistics;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface StatisticsRepository extends JpaRepository<StatisticsEntity, Integer> {
+
+    @Query(value = "SELECT new com.fastcampus.pass.repository.statistics.AggregatedStatistics(s.statisticsAt, SUM(s.allCount), SUM(s.attendedCount), SUM(s.cancelledCount)) " +
+            "         FROM StatisticsEntity s " +
+            "        WHERE s.statisticsAt BETWEEN :from AND :to " +
+            "     GROUP BY s.statisticsAt")
+    List<AggregatedStatistics> findByStatisticsAtBetweenAndGroupBy(@Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+
+}

--- a/src/main/java/com/example/pass/util/CustomCSVWriter.java
+++ b/src/main/java/com/example/pass/util/CustomCSVWriter.java
@@ -1,0 +1,25 @@
+package com.example.pass.util;
+
+import com.opencsv.CSVWriter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.FileWriter;
+import java.util.List;
+
+@Slf4j
+public class CustomCSVWriter {
+
+    public static int write(final String fileName, List<String[]> data) {
+        int rows = 0;
+        try (CSVWriter writer = new CSVWriter(new FileWriter(fileName))) {
+            writer.writeAll(data);
+            rows = data.size();
+        } catch (Exception e) {
+            log.error("CustomCSVWriter - write: CSV 파일 생성 실패, fileName: {}", fileName);
+
+        }
+        return rows;
+
+    }
+
+}


### PR DESCRIPTION
이 PR은 통계 데이터를 생성하고, 일별 및 주별로 집계하여 CSV 파일로 저장하는 배치 작업을 구현 한다. 새로운 Job과 Step을 추가하고, 예약 데이터를 기반으로 통계 데이터를 관리할 수 있도록 설정했다.
